### PR TITLE
add callback framework

### DIFF
--- a/fitment/nuke_fitment/add_callbacks.py
+++ b/fitment/nuke_fitment/add_callbacks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+__author__ = 'andyguo'
+
+import importlib
+import os
+from collections import defaultdict
+
+import nuke
+
+NUKE_FITMENT_ROOT_PATH = os.path.sep.join([os.environ.get('MY_CUSTOM_FITMENT', ''), 'nuke'])
+
+
+def add_callbacks():
+    callback_folder = os.path.sep.join([NUKE_FITMENT_ROOT_PATH, 'callbacks'])
+    if not os.path.isdir(callback_folder):
+        return
+
+    nuke.pluginAppendPath(callback_folder)
+    all_callback_files = [f.split('.')[0] for f in os.listdir(callback_folder) if f.endswith('.py')]
+    callback_auto_load_structure = _go_through_and_find_callback_files(all_callback_files)
+    for node_class, events in callback_auto_load_structure.items():
+        for e in events:
+            _register_callback_on_node(e, node_class)
+
+
+def _register_callback_on_node(e, node_class):
+    try:
+        module = importlib.import_module('_'.join([node_class, e]))
+        callback_func = getattr(module, 'callback', None)
+        nuke_register_callback_func = getattr(nuke, 'add{}'.format(e), None)
+        if callback_func and nuke_register_callback_func:
+            nuke_register_callback_func(callback_func, nodeClass=node_class if node_class != 'All' else '*')
+    except Exception as e:
+        print e
+        pass
+
+
+def _go_through_and_find_callback_files(all_callback_files):
+    callback_auto_load_structure = defaultdict(set)
+    for f in all_callback_files:
+        node_class, event = f.split('_')[:2]
+        callback_auto_load_structure[node_class].add(event)
+    return callback_auto_load_structure

--- a/fitment/nuke_fitment/init.py
+++ b/fitment/nuke_fitment/init.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+__author__ = 'andyguo'

--- a/fitment/nuke_fitment/menu.py
+++ b/fitment/nuke_fitment/menu.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 # @Time    : 1/3/2019 11:26 AM
 
+import add_callbacks
 import add_fitment
 
 add_fitment.add_fitment()
+add_callbacks.add_callbacks()

--- a/nuke/callbacks/Write_KnobChanged.py
+++ b/nuke/callbacks/Write_KnobChanged.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+__author__ = 'andyguo'
+
+import nuke
+
+
+def callback():
+    node = nuke.thisNode()
+    knob = nuke.thisKnob()
+
+    if knob.name() == 'dayu_write_auto_name':
+        _auto_rename(node, knob)
+
+
+def _auto_rename(node, knob):
+    def get_current_nk_filename():
+        nk_file = None
+        try:
+            nk_file = nuke.scriptName()
+        except RuntimeError as e:
+            nuke.alert(e.message)
+        return nk_file
+
+    ext_value = node['dayu_write_ext_list'].value()
+    user_sub_level = node['dayu_write_user_sub_level'].value()
+
+    current_nk_filename = get_current_nk_filename()
+    if current_nk_filename:
+        render_filename = _generate_filename(current_nk_filename, ext_value, user_sub_level)
+        node['file'].setValue(render_filename)
+        node['label'].setValue(user_sub_level)
+
+
+def _generate_filename(current_nk_filename, ext_value, user_sub_level):
+    import os
+    basename = os.path.basename(current_nk_filename)
+    components = basename.split('.')[0].split('_')
+    render_root_path = os.environ.get('DAYU_NUKE_RENDER_PATH', '~')
+    render_file_path = '{root}' \
+                       '{sep}' \
+                       '{sub_level}' \
+                       '{filename}'.format(root=render_root_path,
+                                           sep=os.path.sep,
+                                           sub_level=user_sub_level + os.path.sep if user_sub_level else '',
+                                           filename='_'.join(components) + '.%04d' + ext_value)
+    return render_file_path

--- a/nuke/callbacks/Write_OnCreate.py
+++ b/nuke/callbacks/Write_OnCreate.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+__author__ = 'andyguo'
+
+import nuke
+
+
+def callback():
+    node = nuke.thisNode()
+    tab_knob = nuke.Tab_Knob('dayu', 'Dayu')
+    node.addKnob(tab_knob)
+    _add_auto_name_knobs(node)
+
+
+def _add_auto_name_knobs(node):
+    auto_ext_konb = nuke.CascadingEnumeration_Knob('dayu_write_ext_list', 'format', ['.exr',
+                                                                                     '.dpx',
+                                                                                     '.tif',
+                                                                                     '.png',
+                                                                                     '.jpg',
+                                                                                     '.mov'])
+    auto_ext_konb.setFlag(0x1000)
+    node.addKnob(auto_ext_konb)
+    user_sub_level_knob = nuke.EvalString_Knob('dayu_write_user_sub_level', 'Sub Level')
+    user_sub_level_knob.setFlag(0x1000)
+    node.addKnob(user_sub_level_knob)
+    button_knob = nuke.PyScript_Knob('dayu_write_auto_name', 'Auto Rename')
+    button_knob.setFlag(0x1000)
+    node.addKnob(button_knob)


### PR DESCRIPTION
users can put py files into ./nuke/callbacks, and callbacks will automatically add to specified node on events.

note:
* filename must match:  {node_class}_{event}.py
* there should a callback() function in each py file as an enter point.
* if either node_class or event is invalid, it will print error message and continue running